### PR TITLE
- added akka remote support,

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,16 @@
 name := "Lab2ReactiveScala"
 
-version := "1.1"
+version := "1.4"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 
-lazy val akkaVersion = "2.4.11"
+lazy val akkaVersion = "2.4.12"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
   "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test",
   "com.typesafe.akka" %% "akka-persistence" % akkaVersion,
+  "com.typesafe.akka" %% "akka-remote" % akkaVersion,
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",
   "org.iq80.leveldb" % "leveldb" % "0.7",
   "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8",

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -2,6 +2,10 @@ auctionSystem {
   name = "auctionSystem"
 }
 
+remoteAuctionPublisher {
+  name = "remoteAuctionPublisher"
+}
+
 auction {
   defaultTime = 8000
 }
@@ -16,7 +20,26 @@ auctionSearch {
   name = "auctionSearch"
 }
 
+notifier {
+  name = "notifier"
+}
+
 akka {
+  loglevel = DEBUG
+  actor {
+    provider = "akka.remote.RemoteActorRefProvider"
+    debug {
+      # enable function of LoggingReceive, which is to log any received message at
+      # DEBUG level
+      receive = on
+    }
+  }
+  remote {
+    enabled-transports = ["akka.remote.netty.tcp"]
+    netty.tcp {
+      hostname = "127.0.0.1"
+    }
+  }
   persistence {
     journal {
       plugin = "akka.persistence.journal.leveldb"
@@ -31,6 +54,9 @@ akka {
     }
   }
 }
+
+auctionSystemServer.akka.remote.netty.tcp.port = 2552
+remoteAuctionPublisherServer.akka.remote.netty.tcp.port = 2553
 
 inmemory-read-journal {
   # Absolute path to the write journal plugin configuration section to get the event adapters from

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,21 +1,29 @@
 import akka.actor.ActorSystem
 import auctionsearch.AuctionSearch
 import conf.Conf
+import notifier.Notifier
 import users.{Buyer, Seller}
 
 /**
   * Created by neo on 22.10.16.
   */
 object Main extends App {
-  val system = ActorSystem(Conf.defaultAuctionSystemName)
+  val system = ActorSystem(Conf.defaultAuctionSystemName, Conf.defaultAuctionSystemConfig)
   val auctionSearch = system.actorOf(AuctionSearch.props, Conf.defaultAuctionSearchName)
+  val notifier = system.actorOf(Notifier.props, Conf.defaultNotifierName)
 
-  val seller1 = system.actorOf(Seller.props(List("Auto Czarne Audi", "Auto Czerwona Beemka", "Auto Zielony Fiat")), "seller1")
-  val seller2 = system.actorOf(Seller.props(List("PC Lenovo", "PC Asus")), "seller2")
+  val seller1 = system.actorOf(Seller.props(List("Auto Czarne Audi 972s")), "seller1")
+  val seller2 = system.actorOf(Seller.props(List("PC Lenovo 972s")), "seller2")
 
   val buyer1a = system.actorOf(Buyer.props("Auto", 10), "buyer1a")
-  val buyer1b = system.actorOf(Buyer.props("Auto", 11), "buyer1b")
-  val buyer1c = system.actorOf(Buyer.props("Audi", 9), "buyer1c")
-  val buyer2a = system.actorOf(Buyer.props("PC", 8), "buyer2a")
-  val buyer2b = system.actorOf(Buyer.props("Asus", 12), "buyer2b")
+
+
+  /**
+    * To simulate remote server unavailability comment lines below and run RemoteMain
+    */
+
+  /* val remoteSystem = ActorSystem(Conf.defaultRemoteAuctionPublisherName,
+     Conf.defaultRemoteAuctionPublisherServerConfig)
+
+   val auctionPublisher = remoteSystem.actorOf(AuctionPublisher.props, Conf.defaultRemoteAuctionPublisherName)*/
 }

--- a/src/main/scala/RemoteMain.scala
+++ b/src/main/scala/RemoteMain.scala
@@ -1,0 +1,14 @@
+import akka.actor.ActorSystem
+import conf.Conf
+import remote.AuctionPublisher
+
+/**
+  * Created by neo on 01.12.16.
+  */
+object RemoteMain extends App {
+
+  val remoteSystem = ActorSystem(Conf.defaultRemoteAuctionPublisherName,
+     Conf.defaultRemoteAuctionPublisherServerConfig)
+
+   val auctionPublisher = remoteSystem.actorOf(AuctionPublisher.props, Conf.defaultRemoteAuctionPublisherName)
+}

--- a/src/main/scala/conf/Conf.scala
+++ b/src/main/scala/conf/Conf.scala
@@ -9,7 +9,13 @@ object Conf {
   lazy val conf = ConfigFactory.load()
 
   lazy val defaultAuctionSystemName = conf.getString("auctionSystem.name")
+  lazy val defaultRemoteAuctionPublisherName = conf.getString("remoteAuctionPublisher.name")
   lazy val defaultAuctionSearchName = conf.getString("auctionSearch.name")
+  lazy val defaultNotifierName = conf.getString("notifier.name")
+
+  lazy val defaultAuctionSystemConfig = conf.getConfig("auctionSystemServer").withFallback(conf)
+  lazy val defaultRemoteAuctionPublisherServerConfig = conf.getConfig("remoteAuctionPublisherServer")
+    .withFallback(conf)
 
   lazy val defaultAuctionTime = conf.getInt("auction.defaultTime")
   lazy val defaultBidsPerBuyer = conf.getInt("buyer.defaultBids")

--- a/src/main/scala/notifier/Notifier.scala
+++ b/src/main/scala/notifier/Notifier.scala
@@ -1,0 +1,39 @@
+package notifier
+
+import akka.actor.SupervisorStrategy.{Escalate, Restart, Stop}
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorSelection, OneForOneStrategy, Props}
+import conf.Conf
+import notifier.Notifier.Notify
+import notifier.NotifierRequest.{InvalidHashCodeException, InvalidResponseException, RemoteTimeoutException}
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+/**
+  * Created by neo on 30.11.16.
+  */
+class Notifier extends Actor with ActorLogging {
+
+  val auctionPublisher: ActorSelection =
+    context.actorSelection(s"akka.tcp://${Conf.defaultRemoteAuctionPublisherName}@127.0.0.1:2553/user/${Conf.defaultRemoteAuctionPublisherName}")
+
+  override val supervisorStrategy =
+    OneForOneStrategy(maxNrOfRetries = 10, withinTimeRange = 1 second) {
+      case _: RemoteTimeoutException   => log.info("restarting"); Restart
+      case _: InvalidHashCodeException => log.info("stopping-hash"); Stop
+      case _: InvalidResponseException => log.info("stopping-response"); Stop
+      case _: Exception                => log.info("escalating"); Escalate
+    }
+
+  override def receive: Receive = {
+    case e: Notify =>
+      log.info(s"Got $e. Creating Notifier Request Actor.")
+      context.actorOf(NotifierRequest.props(auctionPublisher, e))
+  }
+}
+
+object Notifier {
+  case class Notify(title: String, currentWinner: ActorRef, currentPrice: Int)
+
+  def props: Props = Props[Notifier]
+}

--- a/src/main/scala/notifier/NotifierRequest.scala
+++ b/src/main/scala/notifier/NotifierRequest.scala
@@ -1,0 +1,58 @@
+package notifier
+
+import akka.actor.{Actor, ActorLogging, ActorSelection, PoisonPill, Props}
+import akka.pattern.ask
+import akka.util.Timeout
+import notifier.Notifier.Notify
+import notifier.NotifierRequest.{InvalidHashCodeException, InvalidResponseException, RemoteTimeoutException, ThrownException}
+import remote.AuctionPublisher.AckNotify
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.{Failure, Success}
+
+/**
+  * Created by neo on 30.11.16.
+  */
+class NotifierRequest(auctionPublisher: ActorSelection, e: Notify) extends Actor with ActorLogging {
+
+  implicit val timeout: Timeout = 2 seconds
+
+  override def preStart = {
+    super.preStart
+    log.info(s"Trying to notify remote server of $e")
+      (auctionPublisher ? e).onComplete {
+        case Failure(ex) => self ! ThrownException(RemoteTimeoutException(ex.getMessage))
+        case Success(AckNotify(hash)) =>
+          if (hash != e.hashCode) self ! ThrownException(InvalidHashCodeException(s"Expected: ${e.hashCode}, got: $hash"))
+          else {
+            log.info(s"Successfully sent $e to remote server")
+            self ! PoisonPill
+          }
+        case Success(response) =>
+          self ! ThrownException(InvalidResponseException(s"Expected AckNotify(${e.hashCode}), got $response"))
+      }
+  }
+
+  override def receive: Receive = {
+    case thrown: ThrownException => throw thrown.ex
+  }
+}
+
+object NotifierRequest {
+
+  /**
+    * God forgive me for I have sinned.
+    * @param ex: exception that cannot be thrown inside of Future context since it's not handled in Supervisor then ;_;
+    */
+  case class ThrownException(ex: Exception)
+
+  case class InvalidHashCodeException(message: String) extends Exception
+
+  case class InvalidResponseException(message: String) extends Exception
+
+  case class RemoteTimeoutException(message: String) extends Exception
+
+  def props(auctionPublisher: ActorSelection, e: Notify): Props = Props(new NotifierRequest(auctionPublisher, e))
+}

--- a/src/main/scala/remote/AuctionPublisher.scala
+++ b/src/main/scala/remote/AuctionPublisher.scala
@@ -1,0 +1,33 @@
+package remote
+
+import akka.actor.{Actor, ActorLogging, Props}
+import notifier.Notifier.Notify
+import remote.AuctionPublisher.AckNotify
+
+/**
+  * Created by neo on 30.11.16.
+  */
+
+/**
+  * To simulate invalid hash, change value inside AckEnvelope response
+  * To simulate invalid response, change AckEnvelope response to sth else
+  */
+class AuctionPublisher extends Actor with ActorLogging {
+
+  override def preStart = {
+    super.preStart
+    log.info("Started Remote Auction Publisher")
+  }
+
+  override def receive: Receive = {
+    case e: Notify =>
+      log.info("Got Notify")
+      sender ! AckNotify(e.hashCode)
+  }
+}
+
+object AuctionPublisher {
+  case class AckNotify(hash: Int)
+
+  def props: Props = Props[AuctionPublisher]
+}


### PR DESCRIPTION
- upgraded Scala to 2.12 and Akka to 2.4.12
- added Notifier and used it in non-fsm Auction,
 - Notifier is auctions bids forwarder to remote actor - AuctionPublisher,
 - Notifier is Supervisor for NotifierRequests which recreates them in case of timeout and stops them when heartbeat from server is invalid
 - left just one auction in Main
 - created RemoteMain object for executing only "remote server" actors